### PR TITLE
Add http(s) port forward

### DIFF
--- a/scripts/start_super_protocol.sh
+++ b/scripts/start_super_protocol.sh
@@ -586,15 +586,15 @@ check_params() {
     if [[ -n "$HTTP_PORT" ]]; then
         echo "Checking http port aviability..."
         if nc -z 0.0.0.0 "$HTTP_PORT"; then
-            echo "https port $HTTP_PORT already bound!";
-            exit 1;
+            echo "http port $HTTP_PORT already bound!"
+            exit 1
         fi
     fi
     if [[ -n "$HTTPS_PORT" ]]; then
         echo "Checking https port aviability..."
         if nc -z 0.0.0.0 "$HTTPS_PORT"; then
             echo "https port $HTTPS_PORT already bound!"
-            exit 1;
+            exit 1
         fi
     fi
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for configuring HTTP and HTTPS ports when starting the VM.
  - Ports can now be set via new command-line options.
  - Script checks and validates port availability before starting.
  - Automatic installation of required network utility if missing.
  - HTTP and HTTPS ports are now included in debug status output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->